### PR TITLE
日時情報用フォーマットプレースホルダーの追加と使用例の拡充

### DIFF
--- a/.github/workflows/gh-pages-demo.yml
+++ b/.github/workflows/gh-pages-demo.yml
@@ -1,0 +1,55 @@
+name: Deploy React Demo to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'examples/react-version-display/**'
+      - '.github/workflows/gh-pages-demo.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          
+      - name: Install Dependencies
+        run: |
+          cd examples/react-version-display
+          npm install
+          
+      - name: Get Current Version
+        id: get-version
+        run: |
+          # show-versionパッケージをグローバルにインストール
+          npm install -g .
+          # バージョン情報を取得
+          VERSION=$(show-version)
+          echo "APP_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Current version: $VERSION"
+          
+      - name: Build
+        run: |
+          cd examples/react-version-display
+          # 環境変数としてバージョンを設定
+          REACT_APP_VERSION="${{ env.APP_VERSION }}" npm run build
+          # GitHub Pages用に.nojekyllファイルを作成
+          touch build/.nojekyll
+          
+      - name: Deploy to GitHub Pages 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: examples/react-version-display/build
+          clean: true 

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -90,7 +90,7 @@ jobs:
           fi
       
       # タグプッシュ時またはオプションで公開が選択された場合にのみnpmにパブリッシュする
-      - name: Publish to npm
+      - name: Setup Node.js for npm publish
         if: (github.event_name == 'push' && github.ref_type == 'tag') || github.event.inputs.publish_npm == 'true'
         uses: actions/setup-node@v4
         with:
@@ -109,11 +109,9 @@ jobs:
             exit 1
           fi
       
-      - name: Publish package
+      - name: Publish package to npm
         if: (github.event_name == 'push' && github.ref_type == 'tag') || github.event.inputs.publish_npm == 'true'
-        run: |
-          echo "npmにパッケージを公開します: @yousan/show-version@${{ steps.get-version.outputs.version }}"
-          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ show-version
 # Custom format
 show-version --format "{tag}-{hash}"
 
+# With datetime information
+show-version --format "{tag}-{datetime}"
+
+# Specify datetime format
+show-version --format "{tag}-{datetime}" --datetime-format YYYYMMDDHHmmss
+
 # Exclude tag information
 show-version --no-tag
 
@@ -163,25 +169,29 @@ if (hasChanges()) {
 
 ### CLI Options
 
-| Option         | Description                           | Default Value            |
-| -------------- | ------------------------------------- | ------------------------ |
-| --format, -f   | Output format                         | {tag}-{branch}-{hash}    |
-| --no-tag       | Exclude tag information               | false                    |
-| --no-branch    | Exclude branch name                   | false                    |
-| --no-hash      | Exclude commit hash                   | false                    |
-| --dirty, -d    | Add flag for uncommitted changes      | false                    |
-| --dirty-suffix | String to append when dirty           | -dirty                   |
-| --dir          | Git repository directory path         | . (current directory)    |
+| Option           | Description                           | Default Value            |
+| ---------------- | ------------------------------------- | ------------------------ |
+| --format, -f     | Output format                         | {tag}-{branch}-{hash}    |
+| --no-tag         | Exclude tag information               | false                    |
+| --no-branch      | Exclude branch name                   | false                    |
+| --no-hash        | Exclude commit hash                   | false                    |
+| --no-datetime    | Exclude datetime information          | false                    |
+| --datetime-format| Datetime format (ISO, YYYYMMDDHHmmss) | ISO                      |
+| --dirty, -d      | Add flag for uncommitted changes      | false                    |
+| --dirty-suffix   | String to append when dirty           | -dirty                   |
+| --dir            | Git repository directory path         | . (current directory)    |
 
 ### API Options
 
 ```javascript
 getVersionAsync({
-  format: '{tag}-{branch}-{hash}', // Output format
-  tag: true,                       // Include tag info
-  branchName: true,                // Include branch name
-  commitHash: true,                // Include commit hash
-  dir: '/path/to/repo'             // Git repository path (default: current directory)
+  format: '{tag}-{branch}-{hash}-{datetime}', // Output format with datetime
+  tag: true,                        // Include tag info
+  branchName: true,                 // Include branch name
+  commitHash: true,                 // Include commit hash
+  datetime: true,                   // Include datetime info
+  datetimeFormat: 'ISO',            // Datetime format (ISO, YYYYMMDDHHmmss, YYYYMMDD)
+  dir: '/path/to/repo'              // Git repository path (default: current directory)
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # show-version
 <!-- auto rewrite started here -->
-[![Version](https://img.shields.io/badge/version-1.1.5-blue.svg)](https://github.com/yousan/show-version/releases/tag/v1.1.5)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](https://github.com/yousan/show-version/releases/tag/v1.2.0)
 
-[![npm version](https://img.shields.io/npm/v/show-version.svg?v=1.1.5)](https://www.npmjs.com/package/show-version)
-[![GitHub package.json version](https://img.shields.io/github/package-json/v/yousan/show-version?v=1.1.5)](https://github.com/yousan/show-version)
-[![GitHub last commit](https://img.shields.io/github/last-commit/yousan/show-version?v=1.1.5)](https://github.com/yousan/show-version/commits)
+[![npm version](https://img.shields.io/npm/v/show-version.svg?v=1.2.0)](https://www.npmjs.com/package/show-version)
+[![GitHub package.json version](https://img.shields.io/github/package-json/v/yousan/show-version?v=1.2.0)](https://github.com/yousan/show-version)
+[![GitHub last commit](https://img.shields.io/github/last-commit/yousan/show-version?v=1.2.0)](https://github.com/yousan/show-version/commits)
 <!-- auto rewrite end here -->
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,65 @@
 
 A simple utility to extract version identifiers (tags, branch names, commit hashes, etc.) from Git repositories. **No Git binary dependency** - operates with pure JavaScript implementation.
 
+## Quick Examples
+
+### React
+
+```jsx
+// ビルド設定 (webpack.config.js)
+const { getVersion } = require('@yousan/show-version');
+
+module.exports = {
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.APP_VERSION': JSON.stringify(getVersion())
+    }),
+  ],
+};
+
+// Versionコンポーネント
+import React from 'react';
+
+const AppVersion = () => (
+  <div className="app-version">Version: {process.env.APP_VERSION}</div>
+);
+
+export default AppVersion;
+```
+
+### Vue
+
+```javascript
+// vite.config.js
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { getVersion } from '@yousan/show-version';
+
+export default defineConfig({
+  plugins: [vue()],
+  define: {
+    'process.env.APP_VERSION': JSON.stringify(getVersion())
+  }
+});
+```
+
+```vue
+<!-- AppVersion.vue -->
+<template>
+  <div class="app-version">Version: {{ version }}</div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      version: process.env.APP_VERSION
+    }
+  }
+}
+</script>
+```
+
 ## Features
 
 - **No Git Binary Dependency**: Works even if Git is not installed on the system

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,7 @@ const argv = yargs(hideBin(process.argv))
   .option('format', {
     alias: 'f',
     type: 'string',
-    description: 'バージョン情報のフォーマット ({tag}, {branch}, {hash})',
+    description: 'バージョン情報のフォーマット ({tag}, {branch}, {hash}, {datetime})',
     default: '{tag}-{branch}-{hash}'
   })
   .option('no-tag', {
@@ -27,6 +27,17 @@ const argv = yargs(hideBin(process.argv))
     type: 'boolean',
     description: 'コミットハッシュを含めない',
     default: false
+  })
+  .option('no-datetime', {
+    type: 'boolean',
+    description: '日時情報を含めない',
+    default: false
+  })
+  .option('datetime-format', {
+    type: 'string',
+    description: '日時のフォーマット (ISO, YYYYMMDDHHmmss, YYYYMMDD)',
+    default: 'ISO',
+    choices: ['ISO', 'YYYYMMDDHHmmss', 'YYYYMMDD']
   })
   .option('dirty', {
     alias: 'd',
@@ -58,6 +69,8 @@ async function main() {
       tag: !argv.noTag,
       branchName: !argv.noBranch,
       commitHash: !argv.noHash,
+      datetime: !argv.noDatetime,
+      datetimeFormat: argv.datetimeFormat,
       dir: argv.dir
     };
     

--- a/examples/react-version-display/.gitignore
+++ b/examples/react-version-display/.gitignore
@@ -1,0 +1,21 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log* 

--- a/examples/react-version-display/package.json
+++ b/examples/react-version-display/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "react-version-display",
+  "version": "0.1.0",
+  "private": true,
+  "homepage": "https://yousan.github.io/show-version",
+  "dependencies": {
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "web-vitals": "^2.1.4"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "gh-pages": "^6.1.1"
+  }
+} 

--- a/examples/react-version-display/public/index.html
+++ b/examples/react-version-display/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+      name="description"
+      content="Show-Version React Demo - Display version from Git repository"
+    />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <title>Show-Version React Demo</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html> 

--- a/examples/react-version-display/public/manifest.json
+++ b/examples/react-version-display/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "short_name": "Show-Version Demo",
+  "name": "Show-Version React Demo",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "logo192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "logo512.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+} 

--- a/examples/react-version-display/src/App.css
+++ b/examples/react-version-display/src/App.css
@@ -1,0 +1,59 @@
+.App {
+  text-align: center;
+  margin: 0 auto;
+  max-width: 800px;
+  padding: 20px;
+}
+
+.App-header {
+  background-color: #282c34;
+  min-height: 20vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.App-link {
+  color: #61dafb;
+}
+
+.version-info {
+  background-color: white;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 20px;
+}
+
+.version-info h2 {
+  color: #282c34;
+  margin-top: 0;
+}
+
+.version-badge {
+  display: inline-block;
+  background-color: #61dafb;
+  color: #282c34;
+  font-weight: bold;
+  padding: 5px 10px;
+  border-radius: 4px;
+  margin: 5px;
+}
+
+.code-example {
+  background-color: #f0f0f0;
+  border-radius: 8px;
+  padding: 20px;
+  text-align: left;
+  overflow-x: auto;
+  margin-bottom: 20px;
+}
+
+pre {
+  margin: 0;
+} 

--- a/examples/react-version-display/src/App.css
+++ b/examples/react-version-display/src/App.css
@@ -22,7 +22,36 @@
   color: #61dafb;
 }
 
-.version-info {
+/* タブナビゲーション */
+.tabs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.tabs button {
+  background-color: #f0f0f0;
+  border: none;
+  padding: 10px 20px;
+  margin: 0 5px 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+.tabs button:hover {
+  background-color: #e0e0e0;
+}
+
+.tabs button.active {
+  background-color: #61dafb;
+  color: #282c34;
+}
+
+/* サンプル表示エリア */
+.version-sample {
   background-color: white;
   border-radius: 8px;
   padding: 20px;
@@ -30,30 +59,212 @@
   margin-bottom: 20px;
 }
 
-.version-info h2 {
-  color: #282c34;
-  margin-top: 0;
+.sample-display {
+  background-color: #f7f7f7;
+  padding: 20px;
+  border-radius: 8px;
+  margin: 20px 0;
+  display: flex;
+  justify-content: center;
 }
 
+/* 基本バージョン表示 */
 .version-badge {
   display: inline-block;
   background-color: #61dafb;
   color: #282c34;
   font-weight: bold;
-  padding: 5px 10px;
-  border-radius: 4px;
-  margin: 5px;
+  padding: 8px 16px;
+  border-radius: 30px;
+  font-size: 1.2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.code-example {
+/* 日時付きバージョン表示 */
+.version-date-info {
+  background-color: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 15px;
+  text-align: left;
+  min-width: 300px;
+  font-size: 1rem;
+}
+
+.version-date-info div {
+  margin: 8px 0;
+}
+
+/* 詳細バージョン情報 */
+.version-detail {
+  background-color: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 15px;
+  text-align: left;
+  min-width: 350px;
+}
+
+.version-detail div {
+  margin: 10px 0;
+  line-height: 1.4;
+}
+
+.commit-link {
+  color: #0366d6;
+  text-decoration: none;
+  margin-left: 5px;
+  font-family: monospace;
+  background-color: #f0f0f0;
+  padding: 2px 5px;
+  border-radius: 3px;
+}
+
+.commit-link:hover {
+  text-decoration: underline;
+  background-color: #e0e0e0;
+}
+
+/* セマンティックバージョン表示 */
+.semantic-version {
+  text-align: center;
+  padding: 10px;
+  min-width: 300px;
+}
+
+.version-parts {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+.version-part {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0 15px;
   background-color: #f0f0f0;
   border-radius: 8px;
-  padding: 20px;
+  padding: 10px;
+  width: 70px;
+}
+
+.version-label {
+  font-size: 0.8rem;
+  color: #666;
+  margin-bottom: 5px;
+}
+
+.version-value {
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #282c34;
+}
+
+.full-version {
+  font-size: 1.2rem;
+  margin-top: 10px;
+  color: #282c34;
+  font-weight: 500;
+}
+
+/* バージョン履歴 */
+.version-history {
+  width: 100%;
+  text-align: left;
+}
+
+.version-history table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+.version-history th, 
+.version-history td {
+  padding: 10px;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.version-history th {
+  background-color: #f0f0f0;
+  font-weight: 500;
+  text-align: left;
+}
+
+.version-history td:first-child {
+  font-family: monospace;
+  font-weight: 500;
+}
+
+/* コード例表示 */
+.code-example {
+  background-color: #f8f8f8;
+  border-radius: 8px;
+  padding: 15px;
   text-align: left;
   overflow-x: auto;
-  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
+.code-example h3 {
+  margin-top: 0;
+  color: #282c34;
+  font-size: 1.1rem;
 }
 
 pre {
   margin: 0;
+  background-color: #292d3e;
+  color: #fff;
+  padding: 15px;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+/* ビルド情報 */
+.build-info {
+  background-color: #f0f0f0;
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 20px;
+}
+
+.build-info h3 {
+  margin-top: 0;
+  color: #282c34;
+  font-size: 1.1rem;
+}
+
+.info-items {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 20px;
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.info-item span {
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 5px;
+}
+
+.info-item strong {
+  font-size: 1rem;
+}
+
+/* フッター */
+footer {
+  margin-top: 30px;
+  padding: 15px;
+  color: #666;
 } 

--- a/examples/react-version-display/src/App.js
+++ b/examples/react-version-display/src/App.js
@@ -1,58 +1,280 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 
 // バージョン情報（本来はビルド時に環境変数として定義されます）
-const APP_VERSION = process.env.REACT_APP_VERSION || 'v1.2.1'; // ビルド時に挿入されなかった場合のフォールバック
+const APP_VERSION = process.env.REACT_APP_VERSION || 'v1.3.0-main-a4ea60e'; // ビルド時に挿入されなかった場合のフォールバック
+const BUILD_DATE = process.env.REACT_APP_BUILD_DATE || new Date().toISOString(); // ビルド日時のフォールバック
 
-// バージョン表示コンポーネント
-const VersionDisplay = ({ version }) => (
+// 1. 基本的なバージョン表示コンポーネント
+const SimpleVersionDisplay = ({ version }) => (
   <div className="version-badge">
     {version}
   </div>
 );
 
+// 2. 日時情報も含むバージョン表示
+const VersionWithDate = () => (
+  <div className="version-date-info">
+    <div><strong>Version:</strong> {APP_VERSION}</div>
+    <div><strong>Build Date:</strong> {new Date(BUILD_DATE).toLocaleString()}</div>
+  </div>
+);
+
+// 3. バージョン・コミットハッシュ・日時を組み合わせた表示
+const FullVersionInfo = () => {
+  // バージョンからハッシュ部分を抽出（例：v1.3.0-main-a4ea60e から a4ea60e を取得）
+  const commitHash = APP_VERSION.split('-').pop();
+  
+  return (
+    <div className="version-detail">
+      <div><strong>Version:</strong> {APP_VERSION}</div>
+      <div>
+        <strong>Commit:</strong> 
+        <a 
+          href={`https://github.com/yousan/show-version/commit/${commitHash}`}
+          target="_blank" 
+          rel="noopener noreferrer"
+          className="commit-link"
+        >
+          {commitHash}
+        </a>
+      </div>
+      <div><strong>Built:</strong> {new Date(BUILD_DATE).toLocaleString()}</div>
+    </div>
+  );
+};
+
+// 4. セマンティックバージョンの分解
+const SemanticVersionDisplay = () => {
+  // バージョン文字列から数字部分を抽出 (例: v1.3.0... から 1.3.0 を取得)
+  const versionNumberMatch = APP_VERSION.match(/v?(\d+\.\d+\.\d+)/);
+  const versionNumber = versionNumberMatch ? versionNumberMatch[1] : '0.0.0';
+  
+  // メジャー、マイナー、パッチに分解
+  const [major, minor, patch] = versionNumber.split('.').map(Number);
+  
+  return (
+    <div className="semantic-version">
+      <div className="version-parts">
+        <div className="version-part">
+          <span className="version-label">Major</span>
+          <span className="version-value">{major}</span>
+        </div>
+        <div className="version-part">
+          <span className="version-label">Minor</span>
+          <span className="version-value">{minor}</span>
+        </div>
+        <div className="version-part">
+          <span className="version-label">Patch</span>
+          <span className="version-value">{patch}</span>
+        </div>
+      </div>
+      <div className="full-version">{versionNumber}</div>
+    </div>
+  );
+};
+
+// 5. バージョン更新履歴を表示（ダミーデータ）
+const VersionHistory = () => {
+  const history = [
+    { version: 'v1.3.0', date: '2025-03-25', changes: '日時フォーマットを追加' },
+    { version: 'v1.2.1', date: '2025-03-20', changes: 'GitHub Actionsによる自動リリース対応' },
+    { version: 'v1.2.0', date: '2025-03-15', changes: 'コマンドラインオプションの拡張' },
+    { version: 'v1.1.0', date: '2025-03-10', changes: 'READMEの改善とサンプル追加' },
+    { version: 'v1.0.0', date: '2025-03-01', changes: '初期リリース' }
+  ];
+  
+  return (
+    <div className="version-history">
+      <h3>リリース履歴</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>バージョン</th>
+            <th>リリース日</th>
+            <th>変更内容</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map(item => (
+            <tr key={item.version}>
+              <td>{item.version}</td>
+              <td>{item.date}</td>
+              <td>{item.changes}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+// メインアプリケーション
 function App() {
+  const [activeTab, setActiveTab] = useState('simple');
+  
+  // タブコンテンツの定義
+  const tabContents = {
+    simple: {
+      title: '基本的なバージョン表示',
+      component: <SimpleVersionDisplay version={APP_VERSION} />,
+      description: 'シンプルなバージョン表示コンポーネント。環境変数からバージョン番号を表示します。',
+      code: `
+const AppVersion = () => (
+  <div className="version-badge">
+    {process.env.APP_VERSION}
+  </div>
+);`
+    },
+    withDate: {
+      title: '日時情報付きバージョン',
+      component: <VersionWithDate />,
+      description: 'バージョン番号に加えてビルド日時も表示します。',
+      code: `
+const VersionWithDate = () => (
+  <div className="version-info">
+    <div>Version: {process.env.APP_VERSION}</div>
+    <div>Build Date: {new Date(process.env.BUILD_DATE).toLocaleString()}</div>
+  </div>
+);`
+    },
+    full: {
+      title: '詳細バージョン情報',
+      component: <FullVersionInfo />,
+      description: 'バージョン番号、コミットハッシュへのリンク、ビルド日時を表示します。',
+      code: `
+const FullVersionInfo = () => {
+  const version = process.env.APP_VERSION;
+  const commitHash = version.split('-').pop();
+  
+  return (
+    <div className="version-detail">
+      <div><strong>Version:</strong> {version}</div>
+      <div><strong>Commit:</strong> 
+        <a href={\`https://github.com/your-repo/commit/\${commitHash}\`}>
+          {commitHash}
+        </a>
+      </div>
+      <div><strong>Built:</strong> {new Date(process.env.BUILD_DATE).toLocaleString()}</div>
+    </div>
+  );
+};`
+    },
+    semantic: {
+      title: 'セマンティックバージョン',
+      component: <SemanticVersionDisplay />,
+      description: 'バージョン番号をメジャー、マイナー、パッチの要素に分解して表示します。',
+      code: `
+const SemanticVersionDisplay = () => {
+  const versionNumberMatch = process.env.APP_VERSION.match(/v?(\\d+\\.\\d+\\.\\d+)/);
+  const versionNumber = versionNumberMatch ? versionNumberMatch[1] : '0.0.0';
+  const [major, minor, patch] = versionNumber.split('.').map(Number);
+  
+  return (
+    <div className="semantic-version">
+      <div className="version-parts">
+        <div className="version-part">
+          <span className="version-label">Major</span>
+          <span className="version-value">{major}</span>
+        </div>
+        <div className="version-part">
+          <span className="version-label">Minor</span>
+          <span className="version-value">{minor}</span>
+        </div>
+        <div className="version-part">
+          <span className="version-label">Patch</span>
+          <span className="version-value">{patch}</span>
+        </div>
+      </div>
+      <div className="full-version">{versionNumber}</div>
+    </div>
+  );
+};`
+    },
+    history: {
+      title: 'バージョン履歴',
+      component: <VersionHistory />,
+      description: 'アプリケーションのバージョン履歴をテーブル形式で表示します。',
+      code: `
+const VersionHistory = () => {
+  const history = [
+    { version: 'v1.3.0', date: '2025-03-25', changes: '日時フォーマットを追加' },
+    { version: 'v1.2.1', date: '2025-03-20', changes: 'GitHub Actionsによる自動リリース対応' },
+    // 省略...
+  ];
+  
+  return (
+    <div className="version-history">
+      <h3>リリース履歴</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>バージョン</th>
+            <th>リリース日</th>
+            <th>変更内容</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map(item => (
+            <tr key={item.version}>
+              <td>{item.version}</td>
+              <td>{item.date}</td>
+              <td>{item.changes}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};`
+    }
+  };
+  
   return (
     <div className="App">
       <header className="App-header">
         <h1>Show-Version Demo</h1>
-        <p>Reactでバージョン情報を表示するサンプル</p>
+        <p>Reactでバージョン情報を表示するサンプル集</p>
       </header>
 
-      <section className="version-info">
-        <h2>アプリケーションバージョン</h2>
-        <VersionDisplay version={APP_VERSION} />
-        <p>このバージョン情報はビルド時にGitリポジトリから抽出されます</p>
+      <div className="tabs">
+        {Object.keys(tabContents).map(key => (
+          <button 
+            key={key}
+            className={activeTab === key ? 'active' : ''}
+            onClick={() => setActiveTab(key)}
+          >
+            {tabContents[key].title}
+          </button>
+        ))}
+      </div>
+
+      <section className="version-sample">
+        <h2>{tabContents[activeTab].title}</h2>
+        <p>{tabContents[activeTab].description}</p>
+        
+        <div className="sample-display">
+          {tabContents[activeTab].component}
+        </div>
+        
+        <div className="code-example">
+          <h3>実装例</h3>
+          <pre>{tabContents[activeTab].code}</pre>
+        </div>
       </section>
 
-      <section className="code-example">
-        <h2>実装例</h2>
-        <h3>1. webpackの設定</h3>
-        <pre>{`
-const webpack = require('webpack');
-const { getVersion } = require('@yousan/show-version');
-
-module.exports = {
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.REACT_APP_VERSION': JSON.stringify(getVersion())
-    }),
-  ],
-};
-        `}</pre>
-        
-        <h3>2. Reactコンポーネント</h3>
-        <pre>{`
-import React from 'react';
-
-const VersionDisplay = () => (
-  <div className="version-badge">
-    {process.env.REACT_APP_VERSION}
-  </div>
-);
-
-export default VersionDisplay;
-        `}</pre>
+      <section className="build-info">
+        <h3>ビルド情報</h3>
+        <div className="info-items">
+          <div className="info-item">
+            <span>現在のアプリバージョン:</span>
+            <strong>{APP_VERSION}</strong>
+          </div>
+          <div className="info-item">
+            <span>ビルド日時:</span>
+            <strong>{new Date(BUILD_DATE).toLocaleString()}</strong>
+          </div>
+        </div>
       </section>
 
       <footer>

--- a/examples/react-version-display/src/App.js
+++ b/examples/react-version-display/src/App.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import './App.css';
+
+// バージョン情報（本来はビルド時に環境変数として定義されます）
+const APP_VERSION = process.env.REACT_APP_VERSION || 'v1.2.1'; // ビルド時に挿入されなかった場合のフォールバック
+
+// バージョン表示コンポーネント
+const VersionDisplay = ({ version }) => (
+  <div className="version-badge">
+    {version}
+  </div>
+);
+
+function App() {
+  return (
+    <div className="App">
+      <header className="App-header">
+        <h1>Show-Version Demo</h1>
+        <p>Reactでバージョン情報を表示するサンプル</p>
+      </header>
+
+      <section className="version-info">
+        <h2>アプリケーションバージョン</h2>
+        <VersionDisplay version={APP_VERSION} />
+        <p>このバージョン情報はビルド時にGitリポジトリから抽出されます</p>
+      </section>
+
+      <section className="code-example">
+        <h2>実装例</h2>
+        <h3>1. webpackの設定</h3>
+        <pre>{`
+const webpack = require('webpack');
+const { getVersion } = require('@yousan/show-version');
+
+module.exports = {
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.REACT_APP_VERSION': JSON.stringify(getVersion())
+    }),
+  ],
+};
+        `}</pre>
+        
+        <h3>2. Reactコンポーネント</h3>
+        <pre>{`
+import React from 'react';
+
+const VersionDisplay = () => (
+  <div className="version-badge">
+    {process.env.REACT_APP_VERSION}
+  </div>
+);
+
+export default VersionDisplay;
+        `}</pre>
+      </section>
+
+      <footer>
+        <p>
+          <a 
+            href="https://github.com/yousan/show-version" 
+            target="_blank"
+            rel="noopener noreferrer"
+            className="App-link"
+          >
+            GitHub リポジトリ
+          </a>
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+export default App; 

--- a/examples/react-version-display/src/index.css
+++ b/examples/react-version-display/src/index.css
@@ -1,0 +1,14 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f5f5;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+} 

--- a/examples/react-version-display/src/index.js
+++ b/examples/react-version-display/src/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+
+reportWebVitals(); 

--- a/examples/react-version-display/src/reportWebVitals.js
+++ b/examples/react-version-display/src/reportWebVitals.js
@@ -1,0 +1,13 @@
+const reportWebVitals = (onPerfEntry) => {
+  if (onPerfEntry && onPerfEntry instanceof Function) {
+    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      getCLS(onPerfEntry);
+      getFID(onPerfEntry);
+      getFCP(onPerfEntry);
+      getLCP(onPerfEntry);
+      getTTFB(onPerfEntry);
+    });
+  }
+};
+
+export default reportWebVitals; 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ const path = require('path');
  * @param {boolean} options.commitHash - コミットハッシュを含めるかどうか
  * @param {boolean} options.branchName - ブランチ名を含めるかどうか
  * @param {boolean} options.tag - タグ情報を含めるかどうか
+ * @param {boolean} options.datetime - 日時情報を含めるかどうか
+ * @param {string} options.datetimeFormat - 日時のフォーマット（'ISO'または'YYYYMMDDHHmmss'）
  * @param {string} options.format - 出力フォーマット
  * @param {string} options.dir - Gitリポジトリのディレクトリパス
  * @returns {Promise<string>} バージョン情報
@@ -17,6 +19,8 @@ async function getVersionAsync(options = {}) {
     commitHash = true,
     branchName = true,
     tag = true,
+    datetime = true,
+    datetimeFormat = 'ISO',
     format = '{tag}-{branch}-{hash}',
     dir = '.'
   } = options;
@@ -89,6 +93,28 @@ async function getVersionAsync(options = {}) {
       }
     } else {
       version = version.replace('{tag}', '');
+    }
+    
+    // 日時情報を追加
+    if (datetime && version.includes('{datetime}')) {
+      const now = new Date();
+      let dateTimeStr;
+      
+      // フォーマットに応じて日時文字列を生成
+      if (datetimeFormat === 'ISO') {
+        // ISO形式: YYYY-MM-DDTHH:mm:ss
+        dateTimeStr = now.toISOString().replace(/\.\d+Z$/, '');
+      } else if (datetimeFormat === 'YYYYMMDDHHmmss') {
+        // 連続形式: YYYYMMDDHHmmss
+        const pad = (num) => String(num).padStart(2, '0');
+        dateTimeStr = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+      } else {
+        // デフォルト形式: YYYYMMDD
+        const pad = (num) => String(num).padStart(2, '0');
+        dateTimeStr = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
+      }
+      
+      version = version.replace('{datetime}', dateTimeStr);
     }
     
     // フォーマットを整理（余計なハイフン等を削除）
@@ -237,6 +263,7 @@ function hasChanges(dir = '.') {
 // - エラーメッセージの改善
 // - デバッグ情報の拡充
 // - 安定性向上
+// - 日時情報の追加: {datetime}フォーマットに対応
 
 module.exports = {
   getVersion,


### PR DESCRIPTION
- **日時情報用のフォーマットプレースホルダー{datetime}を追加**
- **Reactサンプルアプリを拡充：多様なバージョン表示コンポーネントを追加**
- **READMEにサンプル例を追加：日時情報の活用方法とCI/CD例**
